### PR TITLE
fixed

### DIFF
--- a/installation/tools/start_all_vms
+++ b/installation/tools/start_all_vms
@@ -5,8 +5,9 @@
 
 echo "Starting all VMs"
 
+vms_to_start=$(ls ../config/vm/ | tr '\n' '|' | sed 's/.$//') 
 list_shutdown_domains() {
-	virsh list --inactive | grep "shut off" | awk '{ print $2}'
+	virsh list --inactive | grep "shut off" | grep -E $vms_to_start | awk '{ print $2}'
 }
 
 list_shutdown_domains | while read DOMAIN; do


### PR DESCRIPTION
Before, the script would simply start all inactive VMs in virsh and wait for their start. This is especially problematic if these VMs fail during their start, which causes a deadlock. With the fix, the script only tries to start the actually required VMs.
