### PR TITLE
add group vars to openstack installation

### DIFF
--- a/multinode_installation/installation_changed_files/group_vars/all.yml.j2
+++ b/multinode_installation/installation_changed_files/group_vars/all.yml.j2
@@ -1,0 +1,3 @@
+---
+region:
+  role: {{ "master" if region_id == 1 else "slave" }}

--- a/multinode_installation/playbooks/copy_installation_script.yml
+++ b/multinode_installation/playbooks/copy_installation_script.yml
@@ -11,9 +11,13 @@
         - install.sh
         - delete_unnecessary_iptables_rules.yml
         - setup_virtual_machines.sh
+
+    - name: Ensures {{installation_folder}}/installation/group_vars dir exists
+      file: path={{installation_folder }}/installation/group_vars state=directory
     - name: Patch by template
       template: src=../installation_changed_files/{{ item }}.j2  dest={{ installation_folder }}/installation/{{ item }} backup=yes  mode="u=rwx"
       with_items:
         - config/installation_configuration.sh
         - config/network/management.xml
+        - group_vars/all.yml
 


### PR DESCRIPTION
A region needs to know if it's a 'master region' or a 'slave region'. I decided to add a folder 'group vars' to the virtualized installation. Why not in [config/installation_configuration.sh](https://github.com/MasterprojectOpenStack2015/sourcecode/blob/master/installation/config/installation_configuration.sh) ? Because we add a **new** variable, that is not relevant for the former installation process. And IMO the environment variables defined in a shell script are a code smell. Why not in [config/ansible/ansible.cfg](https://github.com/MasterprojectOpenStack2015/sourcecode/blob/master/installation/config/ansible/ansible.cfg)? Because these variables are ansible-specific not application-specific. From my understanding, application-specific variables in ansible should go into a folder called [group_vars/](http://docs.ansible.com/ansible/playbooks_best_practices.html#group-and-host-variables).
