### PR TITLE
parameterize region_name

### DIFF
--- a/installation/playbooks/03_Add_the_Identity_service/03_Create_the_service_entity_and_API_endpoint.yml
+++ b/installation/playbooks/03_Add_the_Identity_service/03_Create_the_service_entity_and_API_endpoint.yml
@@ -15,4 +15,4 @@
     shell: 'openstack service create --name keystone --description "OpenStack Identity" identity'
 
   - name: "Create the Identity service API endpoint"
-    shell: "openstack endpoint create --publicurl {{ config.identity_public_url }} --internalurl {{ config.identity_internal_url }} --adminurl {{ config.identity_admin_url }} --region RegionOne identity"
+    shell: "openstack endpoint create --publicurl {{ config.identity_public_url }} --internalurl {{ config.identity_internal_url }} --adminurl {{ config.identity_admin_url }} --region {{ region.name }} identity"

--- a/installation/playbooks/03_Add_the_Identity_service/06_Create_OpenStack_client_environment_scripts/admin-openrc.sh.j2
+++ b/installation/playbooks/03_Add_the_Identity_service/06_Create_OpenStack_client_environment_scripts/admin-openrc.sh.j2
@@ -8,6 +8,7 @@ export OS_USERNAME=admin
 export OS_PASSWORD={{ config.openstack_admin_user_password }}
 # this should be {{ config.os_auth_admin_url }}/v3
 export OS_AUTH_URL={{ config.os_auth_admin_url }}/v3
+export OS_REGION_NAME={{ region.name }}
 
 # from http://docs.openstack.org/kilo/install-guide/install/apt/content/glance-verify.html
 export OS_IMAGE_API_VERSION=2

--- a/installation/playbooks/03_Add_the_Identity_service/06_Create_OpenStack_client_environment_scripts/demo-openrc.sh.j2
+++ b/installation/playbooks/03_Add_the_Identity_service/06_Create_OpenStack_client_environment_scripts/demo-openrc.sh.j2
@@ -8,6 +8,7 @@ export OS_USERNAME=demo
 export OS_PASSWORD={{ config.openstack_demo_user_password }}
 # should be {{ config.os_auth_user_url }}/v3
 export OS_AUTH_URL={{ config.os_auth_user_url }}/v3
+export OS_REGION_NAME={{ region.name }}
 
 # from http://docs.openstack.org/kilo/install-guide/install/apt/content/glance-verify.html
 export OS_IMAGE_API_VERSION=2

--- a/installation/playbooks/04_Add_the_Image_service/02_Install_and_configure/01_configure_prerequisites.yml
+++ b/installation/playbooks/04_Add_the_Image_service/02_Install_and_configure/01_configure_prerequisites.yml
@@ -57,4 +57,4 @@
   # ----------------------------------------
 
   - name: 4. Create the Image service API endpoint
-    shell: "openstack endpoint create --publicurl {{ config.glance_os_url }} --internalurl {{ config.glance_os_url }} --adminurl {{ config.glance_os_url }} --region RegionOne image"
+    shell: "openstack endpoint create --publicurl {{ config.glance_os_url }} --internalurl {{ config.glance_os_url }} --adminurl {{ config.glance_os_url }} --region {{ region.name }} image"

--- a/installation/playbooks/05_Add_the_Compute_service/02_Install_and_configure_controller_node/01_configure_prerequisites.yml
+++ b/installation/playbooks/05_Add_the_Compute_service/02_Install_and_configure_controller_node/01_configure_prerequisites.yml
@@ -56,6 +56,6 @@
     # ------------------------------------------
   
     - name: 4. Create the Compute service API endpoint
-      shell: 'openstack endpoint create --publicurl http://{{ config.controller_node_hostname }}:8774/v2/%\(tenant_id\)s --internalurl http://{{ config.controller_node_hostname }}:8774/v2/%\(tenant_id\)s --adminurl http://{{ config.controller_node_hostname }}:8774/v2/%\(tenant_id\)s --region RegionOne compute'
+      shell: 'openstack endpoint create --publicurl http://{{ config.controller_node_hostname }}:8774/v2/%\(tenant_id\)s --internalurl http://{{ config.controller_node_hostname }}:8774/v2/%\(tenant_id\)s --adminurl http://{{ config.controller_node_hostname }}:8774/v2/%\(tenant_id\)s --region {{ region.name }} compute'
 
 

--- a/installation/playbooks/06_Add_a_Networking_component/03_Install_and_configure_controller_node/01_configure_prerequisites.yml
+++ b/installation/playbooks/06_Add_a_Networking_component/03_Install_and_configure_controller_node/01_configure_prerequisites.yml
@@ -61,5 +61,5 @@
                         --publicurl http://{{ config.controller_node_hostname }}:9696 
                         --adminurl http://{{ config.controller_node_hostname }}:9696 
                         --internalurl http://{{ config.controller_node_hostname }}:9696 
-                        --region RegionOne network'
+                        --region {{ region.name }} network'
 

--- a/installation/playbooks/06_Add_a_Networking_component/03_Install_and_configure_controller_node/02_Install_and_configure_controller_node.yml
+++ b/installation/playbooks/06_Add_a_Networking_component/03_Install_and_configure_controller_node/02_Install_and_configure_controller_node.yml
@@ -89,7 +89,7 @@
       - { option: 'auth_plugin', value: 'password' }
       - { option: 'project_domain_id', value: 'default' }
       - { option: 'user_domain_id', value: 'default' }
-      - { option: 'region_name', value: 'RegionOne' }
+      - { option: 'region_name', value: '{{ region.name }}' }
       - { option: 'project_name', value: 'service' }
       - { option: 'username', value: 'nova' }
       - { option: 'password', value: '{{ config.nova_user_password }}' }

--- a/installation/playbooks/06_Add_a_Networking_component/04_Install_and_configure_network_node/07_configure_the_metadata_agent.yml
+++ b/installation/playbooks/06_Add_a_Networking_component/04_Install_and_configure_network_node/07_configure_the_metadata_agent.yml
@@ -18,7 +18,7 @@
       # 1.a In the [DEFAULT] section, configure access parameters
       - { option: 'auth_uri', value: 'http://{{ config.controller_node_hostname }}:5000' }
       - { option: 'auth_url', value: 'http://{{ config.controller_node_hostname }}:35357' }
-      - { option: 'auth_region', value: 'RegionOne' }
+      - { option: 'auth_region', value: '{{ region.name }}' }
       - { option: 'auth_plugin', value: 'password' }
       - { option: 'project_domain_id', value: 'default' }
       - { option: 'user_domain_id', value: 'default' }

--- a/installation/playbooks/09_Add_Object_Storage/02_Install_and_configure_the_controller_node/01_configure_prerequisites.yml
+++ b/installation/playbooks/09_Add_Object_Storage/02_Install_and_configure_the_controller_node/01_configure_prerequisites.yml
@@ -26,4 +26,4 @@
     shell: 'openstack service create --name swift --description "OpenStack Object Storage" object-store'
 
   - name: "3. Create the swift service entity"
-    shell: "openstack endpoint create --publicurl \'http://{{ config.controller_node_hostname }}:8080/v1/AUTH_%(tenant_id)s\' --internalurl \'http://{{ config.controller_node_hostname }}:8080/v1/AUTH_%(tenant_id)s\' --adminurl http://{{ config.controller_node_hostname }}:8080 --region RegionOne object-store"
+    shell: "openstack endpoint create --publicurl \'http://{{ config.controller_node_hostname }}:8080/v1/AUTH_%(tenant_id)s\' --internalurl \'http://{{ config.controller_node_hostname }}:8080/v1/AUTH_%(tenant_id)s\' --adminurl http://{{ config.controller_node_hostname }}:8080 --region {{ region.name }} object-store"

--- a/multinode_installation/installation_changed_files/group_vars/all.yml.j2
+++ b/multinode_installation/installation_changed_files/group_vars/all.yml.j2
@@ -1,3 +1,4 @@
 ---
 region:
   role: {{ "master" if region_id == 1 else "slave" }}
+  name: "region{{region_id}}"


### PR DESCRIPTION
This is an intermediate step to get to #30. Assign each region a unique name, which is currently hard coded and always "RegionOne".

Keep the PRs small..
